### PR TITLE
updates for logged-in password changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The following API methods are always available to integrate your AuthN service (
 * `KeratinAuthN.isAvailable(username: string): Promise<boolean>`: returns a Promise that is fulfilled with an indication whether the username is available or has been claimed.
 * `KeratinAuthN.refresh(): Promise<string>`: returns a Promise that is fulfilled with a fresh ID Token unless the user has been logged-out from AuthN
 * `KeratinAuthN.requestPasswordReset(username: string): Promise<>`: requests a password reset for the given username and _always claims to succeed_. If this truly succeeds, AuthN will send a reset token to your server for email delivery.
-* `KeratinAuthN.resetPassword(obj: {password: string, token: string}): Promise<string>`: returns a Promise that is fulfilled when the password has been reset for the account identified by the authorizing token (previously delivered to app as a result of `requestPasswordReset`. May error with password validations, or invalid/expired tokens.
+* `KeratinAuthN.changePassword(obj: {password: string, token?: string}): Promise<string>`: returns a Promise that is fulfilled when the password has been reset. If the user is currently logged in, no token is necessary. If the user is logged out, a token generated as a result of `requestPasswordReset` must be provided. May error with password validations, or invalid/expired tokens.
 
 If you have loaded `keratin-authn.cookie`, then:
 
 * `KeratinAuthN.setSessionName(name: string): void` will configure the cookie name and automatically begin monitoring and refreshing the cookie before it expires. You should call this on each page load.
-* `KeratinAuthN.signup()`, `KeratinAuthN.login()`, and `KeratinAuthN.resetPassword()` will automatically set the ID Token as a cookie.
+* `KeratinAuthN.signup()`, `KeratinAuthN.login()`, and `KeratinAuthN.changePassword()` will automatically set the ID Token as a cookie.
 * `KeratinAuthN.logout()` will automatically delete the ID Token cookie.
 
 ## Development

--- a/src/api.ts
+++ b/src/api.ts
@@ -70,7 +70,7 @@ export function requestPasswordReset(username: string): Promise<EmptyResponse> {
   return get(url('/password/reset'), {username});
 }
 
-export function resetPassword(args: PasswordResetArgs): Promise<string> {
+export function changePassword(args: {password: string, token?: string}): Promise<string> {
   return post<TokenResponse>(url('/password'), args)
     .then((result) => result.id_token);
 }

--- a/src/form_data.ts
+++ b/src/form_data.ts
@@ -1,14 +1,17 @@
 export interface FormData {
-  [index: string]: string;
+  [index: string]: string | undefined;
 }
 
 // takes a simple map, returns a string
 export function formData(data: FormData): string {
   return Object.keys(data)
     .map((k) => formDataItem(k, data[k]))
+    .filter((str) => str !== undefined)
     .join('&');
 }
 
-function formDataItem(k: string, v: string): string {
-  return `${k}=${encodeURIComponent(v)}`;
+function formDataItem(k: string, v: string | undefined): string | undefined {
+  if (typeof v !== "undefined") {
+    return `${k}=${encodeURIComponent(v)}`;
+  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,9 +27,3 @@ interface SessionStore {
   update(val: string): void,
   delete(): void
 }
-
-interface PasswordResetArgs {
-  [index: string]: string;
-  password: string;
-  token: string;
-}

--- a/src/main.cookie.ts
+++ b/src/main.cookie.ts
@@ -1,6 +1,6 @@
 import { SessionManager } from "./session_manager";
 import { CookieSessionStore } from "./cookie_store";
-import { signup as signupAPI, login as loginAPI, logout as logoutAPI, resetPassword as resetPasswordAPI } from "./api";
+import { signup as signupAPI, login as loginAPI, logout as logoutAPI, changePassword as changePasswordAPI } from "./api";
 
 const unconfigured: string = "AuthN must be configured with setSession()";
 
@@ -31,8 +31,8 @@ export function logout(): Promise<void> {
     });
 }
 
-export function resetPassword(args: PasswordResetArgs): Promise<string> {
-  return resetPasswordAPI(args)
+export function changePassword(args: {password: string, token?: string}): Promise<string> {
+  return changePasswordAPI(args)
     .then(updateAndReturn);
 }
 


### PR DESCRIPTION
In https://github.com/keratin/authn/pull/34, the token argument became optional for resetting passwords. This endpoint is now intended to be used for both logged-in and logged-out password changes.