### PR TITLE
promise errors interface

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -19,7 +19,7 @@ export function signup(credentials: Credentials): Promise<string> {
     reject: (errors: Error[]) => any
   ) => {
     if (inflight) {
-      reject([{field: '', message: "duplicate"}]);
+      reject([{message: "duplicate"}]);
       return;
     } else {
       inflight = true;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { get, post } from "./verbs";
-import { Credentials } from "./types";
+import { Credentials, Error } from "./types";
 
 let inflight: boolean = false;
 
@@ -14,9 +14,12 @@ interface TokenResponse{
 }
 
 export function signup(credentials: Credentials): Promise<string> {
-  return new Promise((fulfill, reject) => {
+  return new Promise((
+    fulfill: (data?: string) => any,
+    reject: (errors: Error[]) => any
+  ) => {
     if (inflight) {
-      reject("duplicate");
+      reject([{field: '', message: "duplicate"}]);
       return;
     } else {
       inflight = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,6 @@ export interface FormData {
 }
 
 export interface Error {
-  field: string;
+  field?: string;
   message: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,8 @@ export interface SessionStore {
 export interface FormData {
   [index: string]: string | undefined;
 }
+
+export interface Error {
+  field: string;
+  message: string;
+}

--- a/src/verbs.ts
+++ b/src/verbs.ts
@@ -34,7 +34,7 @@ function jhr<T>(sender: (xhr: XMLHttpRequest) => void): Promise<T> {
         } else if (xhr.status >= 200 && xhr.status < 400) {
           fulfill()
         } else {
-          reject([{field: '', message: xhr.statusText}]);
+          reject([{message: xhr.statusText}]);
         }
       }
     };

--- a/test/tests.js
+++ b/test/tests.js
@@ -61,14 +61,6 @@ function assertInstalledToken(assertions) {
   }
 }
 
-function assertErrors(assertions) {
-  return function (errors) {
-    assertions.equal(errors.length, 1, "one error");
-    assertions.ok(errors[0].field, 'error has field');
-    assertions.ok(errors[0].message, 'error has message');
-  };
-}
-
 function refuteSuccess(assertions) {
   return function (data) {
     assertions.notOk(true, "should not succeed");
@@ -100,7 +92,9 @@ QUnit.test("failure", function(assert) {
 
   return KeratinAuthN.signup({username: 'test', password: 'test'})
     .then(refuteSuccess(assert))
-    .catch(assertErrors(assert));
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{field: 'foo', message: 'bar'}]);
+    });
 });
 QUnit.test("double submit", function(assert) {
   var done = assert.async(2);
@@ -117,9 +111,9 @@ QUnit.test("double submit", function(assert) {
   KeratinAuthN.signup({username: 'test', password: 'test'})
     .then(refuteSuccess(assert))
     .catch(function(errors) {
-      assert.equal(errors, "duplicate", "caught duplicate request");
+      assert.deepEqual(errors, [{field: '', message: 'duplicate'}]);
       done();
-    })
+    });
 
   this.server.respond();
 });
@@ -142,7 +136,9 @@ QUnit.test("name is taken", function(assert) {
 
   return KeratinAuthN.isAvailable('test')
     .then(refuteSuccess(assert))
-    .catch(assertErrors(assert));
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{field: 'username', message: 'TAKEN'}]);
+    });
 });
 
 QUnit.module("setSessionName", startServer);
@@ -190,7 +186,9 @@ QUnit.test("failure", function(assert) {
 
   return KeratinAuthN.login({username: 'test', password: 'test'})
     .then(refuteSuccess(assert))
-    .catch(assertErrors(assert));
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{field: 'foo', message: 'bar'}]);
+    });
 });
 
 QUnit.module("requestPasswordReset", startServer);
@@ -235,7 +233,9 @@ QUnit.test("failure", function(assert) {
       token: jwt({foo: 'bar'})
     })
     .then(refuteSuccess(assert))
-    .catch(assertErrors(assert));
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{field: 'foo', message: 'bar'}]);
+    });
 });
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -111,7 +111,7 @@ QUnit.test("double submit", function(assert) {
   KeratinAuthN.signup({username: 'test', password: 'test'})
     .then(refuteSuccess(assert))
     .catch(function(errors) {
-      assert.deepEqual(errors, [{field: '', message: 'duplicate'}]);
+      assert.deepEqual(errors, [{message: 'duplicate'}]);
       done();
     });
 


### PR DESCRIPTION
Stop rejecting promises with strings. Use a consistent `Error`(-like) interface.