### PR TITLE
implement LocalStorageSessionStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ KeratinAuthN currently depends on [CORS support](http://caniuse.com/#search=cors
 
 KeratinAuthN also requires global support for ES6 Promises. You can get a polyfill from https://github.com/stefanpenner/es6-promise.
 
+### Persistence Options
+
+KeratinAuthN offers three persistence modes, each useful to a different type of application:
+
+1. **Memory:** The default `main` bundle will only track a login in memory. This is useful for single-page applications where the user can be logged out on each new page load.
+
+2. **LocalStorage:** The `main.localstorage` bundle adds support for localStorage-backed persistence. This is useful for client-side applications that do not rely on server-side rendering to generate a personalized page. The client is responsible for reading from `KeratinAuthN.session()` and adding the session token to any backend API requests.
+
+3. **Cookie:** The `main.cookie` bundle adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but requires the application to implement CSRF protection mechanisms.
+
+
 ### NPM or Yarn
 
 Fetch the node module from NPM:
@@ -19,13 +30,23 @@ Fetch the node module from NPM:
 * `npm install keratin-authn`
 * `yarn add keratin-authn`
 
-Then choose between the default memory-backed client (user will begin as logged out on each page load):
+Then choose between the default memory-backed client:
 
 ```javascript
 // the minimal API client
 var AuthN = require("keratin-authn");
 
 AuthN.setHost("https://authn.myapp.com");
+```
+
+Or the client with localStorage persistence support:
+
+```javascript
+var AuthN = require("keratin-authn/dist/keratin-authn.localstorage");
+
+// configuration
+AuthN.setHost("https://authn.myapp.com");
+AuthN.setSessionName('authn');
 ```
 
 Or the client with cookie persistence support:
@@ -40,15 +61,15 @@ AuthN.setSessionName('authn');
 
 ### Other
 
-Fetch one of the standalone distributions built with UMD: [keratin-authn.min.js](https://unpkg.com/keratin-authn/dist/keratin-authn.min.js) or [keratin-authn.cookie.min.js](https://unpkg.com/keratin-authn/dist/keratin-authn.cookie.min.js)
+Fetch one of the standalone distributions built with UMD: [keratin-authn.min.js](https://unpkg.com/keratin-authn/dist/keratin-authn.min.js) or [keratin-authn.localstorage.min.js](https://unpkg.com/keratin-authn/dist/keratin-authn.localstorage.min.js) or [keratin-authn.cookie.min.js](https://unpkg.com/keratin-authn/dist/keratin-authn.cookie.min.js)
 
-Load or concatenate `dist/keratin-authn.min.js` or `dist/keratin-authn.cookie.min.js` according to your vendoring process, then configure:
+Load or concatenate `dist/keratin-authn.min.js` (or `dist/keratin-authn.cookie.min.js` or `dist/keratin-authn.localstorage.min.js`) according to your vendoring process, then configure:
 
 ```html
 <script type="text/javascript">
   KeratinAuthN.setHost("https://authn.myapp.com");
 
-  // if you sourced keratin-authn.cookie:
+  // if you sourced keratin-authn.cookie or keratin-authn.localstorage:
   KeratinAuthN.setSessionName('authn');
 </script>
 ```
@@ -65,9 +86,9 @@ The following API methods are always available to integrate your AuthN service (
 * `KeratinAuthN.requestPasswordReset(username: string): Promise<>`: requests a password reset for the given username and _always claims to succeed_. If this truly succeeds, AuthN will send a reset token to your server for email delivery.
 * `KeratinAuthN.changePassword(obj: {password: string, token?: string}): Promise<void>`: returns a Promise that is fulfilled when the password has been reset. If the user is currently logged in, no token is necessary. If the user is logged out, a token generated as a result of `requestPasswordReset` must be provided. Establishes a session. May error with password validations, or invalid/expired tokens.
 
-If you have loaded `keratin-authn.cookie`, then:
+If you have loaded `keratin-authn.cookie` or `keratin-authn.localstorage`, then:
 
-* `KeratinAuthN.setSessionName(name: string): void` will configure AuthN to read and write a named cookie for session persistence. You should call this on each page load.
+* `KeratinAuthN.setSessionName(name: string): void` will configure AuthN to read and write from a named cookie or from localStorage for session persistence. You should call this on each page load.
 
 ## Development
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,9 +33,13 @@ gulp.task('build-cookie', ['compile'], function() {
   return build('cookie');
 });
 
-gulp.task('default', ['build-core', 'build-cookie']);
+gulp.task('build-localstorage', ['compile'], function() {
+  return build('localstorage');
+});
 
-gulp.task('test', ['build-core', 'build-cookie'], function () {
+gulp.task('default', ['build-core', 'build-cookie', 'build-localstorage']);
+
+gulp.task('test', ['default'], function () {
   return gulp.src('./test/runner.html')
     .pipe(qunit());
 });

--- a/src/LocalStorageSessionStore.ts
+++ b/src/LocalStorageSessionStore.ts
@@ -1,0 +1,21 @@
+import JWTSession from "./JWTSession";
+
+export default class LocalStorageSessionStore implements SessionStore {
+  private readonly sessionName: string;
+
+  constructor(name: string) {
+    this.sessionName = name;
+  }
+
+  read(): string | undefined {
+    return window.localStorage.getItem(this.sessionName) || undefined;
+  }
+
+  update(val: string) {
+    window.localStorage.setItem(this.sessionName, val);
+  }
+
+  delete() {
+    window.localStorage.removeItem(this.sessionName);
+  }
+}

--- a/src/main.localstorage.ts
+++ b/src/main.localstorage.ts
@@ -1,0 +1,10 @@
+import LocalStorageSessionStore from "./LocalStorageSessionStore";
+import { setStore } from "./main";
+
+// all of main
+export * from "./main";
+
+// plus cookie config
+export function setSessionName(sessionName: string): void {
+  setStore(new LocalStorageSessionStore(sessionName));
+}


### PR DESCRIPTION
Adds a localStorage persistence option, available through the `main.localstorage` bundle.

LocalStorage is an appropriate persistence option for client-side applications that don't rely on server-side rendering to generate the first page load in a logged-in state. That only works with cookies, which provide ambient authentication.

The upside is that client-side apps relying on localStorage for persistence are not vulnerable to CSRF attacks, which exploit the ambient behavior of cookies.