### PR TITLE
fix bug with detecting early clocks

### DIFF
--- a/src/JWTSession.ts
+++ b/src/JWTSession.ts
@@ -10,11 +10,11 @@ export default class JWTSession implements Session {
   }
 
   iat() {
-    return this.claims.iat;
+    return this.claims.iat * 1000;
   }
 
   exp() {
-    return this.claims.exp;
+    return this.claims.exp * 1000;
   }
 
   halflife() {

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -25,8 +25,8 @@ export default class SessionManager {
       return;
     }
 
-    const refreshAt = (this.session.iat() + this.session.halflife()) * 1000; // in ms
-    const now = (new Date).getTime();
+    const refreshAt = (this.session.iat() + this.session.halflife());
+    const now = (new Date).getTime(); // in ms
 
     // NOTE: if the client's clock is quite wrong, we'll end up being pretty aggressive about
     // maintaining their session on pretty much every page load.
@@ -42,7 +42,7 @@ export default class SessionManager {
       this.store.update(id_token);
     }
     this.session = new JWTSession(id_token);
-    this.scheduleRefresh(this.session.halflife() * 1000);
+    this.scheduleRefresh(this.session.halflife());
   }
 
   private scheduleRefresh(delay: number): void {


### PR DESCRIPTION
Bug: the detection for clocks set in the past was comparing integer seconds against integer milliseconds. The integer milliseconds were always bigger.

Solution: milliseconds all the way down.