### PR TITLE
Restoring expired tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ KeratinAuthN.setHost(url: string): void
 
 ```javascript
 // Configure AuthN to read and write from a named cookie for session persistence.
-KeratinAuthN.setCookieStore(name: string): void
+// Returns a Promise that is fulfilled if a session was restored from an existing cookie.
+KeratinAuthN.setCookieStore(name: string): Promise<void>
 ```
 
 ```javascript
 // Configure AuthN to read and write from localStorage for session persistence.
-KeratinAuthN.setLocalStorageStore(name: string): void
+// Returns a Promise that is fulfilled if a session was restored from localStorage.
+KeratinAuthN.setLocalStorageStore(name: string): Promise<void>
 ```
 
 ## API

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 let manager = new SessionManager();
 function setStore(store: SessionStore): void {
   manager.setStore(store);
-  manager.maintain();
+  manager.restoreSession();
 }
 
 export function setCookieStore(sessionName: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,17 @@ import {
 } from "./api";
 
 let manager = new SessionManager();
-function setStore(store: SessionStore): void {
+function setStore(store: SessionStore): Promise<void> {
   manager.setStore(store);
-  manager.restoreSession();
+  return manager.restoreSession();
 }
 
-export function setCookieStore(sessionName: string): void {
-  setStore(new CookieSessionStore(sessionName));
+export function setCookieStore(sessionName: string): Promise<void> {
+  return setStore(new CookieSessionStore(sessionName));
 }
 
-export function setLocalStorageStore(sessionName: string): void {
-  setStore(new LocalStorageSessionStore(sessionName));
+export function setLocalStorageStore(sessionName: string): Promise<void> {
+  return setStore(new LocalStorageSessionStore(sessionName));
 }
 
 export function session(): string | undefined {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "module": "commonjs",
 
     // output files
-    "listEmittedFiles": true,
     "declaration": true,
     "outDir": "./lib",
 


### PR DESCRIPTION
When an app (page) initializes, Keratin looks for an existing token and kicks off its maintenance strategy. This was happening behind the scenes, with no way for the host app to know if and when a session had been found.

Further, the existing token might have expired. Keratin would attempt to refresh it, but would meanwhile expose the expired token to the host app.

This changeset fixes both. The `setFooStore` methods will now return a promise that is fulfilled when a session is found and viable. This is an asynchronous process because it might require first refreshing the token from the AuthN server.

fixes #13  