### PR TITLE
`resetPassword` vs `changePassword`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ KeratinAuthN.setLocalStorageStore(name: string): void
 Use the following API methods to integrate your AuthN service:
 
 ```javascript
-// check the configured storage for an existing session. refresh it if necessary.
-// the promise is fulfilled if a session is restored.
+// Check the configured storage for an existing session. Refresh it if necessary.
+// The promise is fulfilled if a session is restored.
 KeratinAuthN.restoreSession(): Promise<void>
 ```
 
@@ -103,11 +103,18 @@ KeratinAuthN.requestPasswordReset(username: string): Promise<>
 ```
 
 ```javascript
-// Returns a Promise that is fulfilled when the password has been reset.
-// If the user is currently logged in, no token is necessary. If the user is logged out, a token generated as a result of `requestPasswordReset` must be provided.
+// Changes the password of the currently logged-in user.
+// Establishes a session.
+// May error with password validations, or an invalid currentPassword.
+KeratinAuthN.changePassword(obj: {password: string, currentPassword: string}): Promise<void>
+```
+
+```javascript
+// Resets the password of a user who is unable to log in.
+// Must be given a token generated through `requestPasswordReset`.
 // Establishes a session.
 // May error with password validations, or invalid/expired tokens.
-KeratinAuthN.changePassword(obj: {password: string, token?: string}): Promise<void>
+KeratinAuthN.resetPassword(obj: {password: string, token: string}): Promise<void>
 ```
 
 ## Development

--- a/src/api.ts
+++ b/src/api.ts
@@ -60,7 +60,12 @@ export function requestPasswordReset(username: string): Promise<{}> {
   return get(url('/password/reset'), {username});
 }
 
-export function changePassword(args: {password: string, token?: string}): Promise<string> {
+export function changePassword(args: {password: string, currentPassword: string}): Promise<string> {
+  return post<TokenResponse>(url('/password'), args)
+    .then((result) => result.id_token);
+}
+
+export function resetPassword(args: {password: string, token: string}): Promise<string> {
   return post<TokenResponse>(url('/password'), args)
     .then((result) => result.id_token);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,7 @@ import { Credentials, SessionStore } from './types';
 import SessionManager from './SessionManager';
 import CookieSessionStore from "./CookieSessionStore";
 import LocalStorageSessionStore from "./LocalStorageSessionStore";
-import {
-  signup as signupAPI,
-  login as loginAPI,
-  logout as logoutAPI,
-  changePassword as changePasswordAPI
-} from "./api";
+import * as API from './api';
 
 let manager = new SessionManager();
 function setStore(store: SessionStore): void {
@@ -31,22 +26,27 @@ export function session(): string | undefined {
 }
 
 export function signup(credentials: Credentials): Promise<void> {
-  return signupAPI(credentials)
+  return API.signup(credentials)
     .then(updateStore);
 }
 
 export function login(credentials: Credentials): Promise<void> {
-  return loginAPI(credentials)
+  return API.login(credentials)
     .then(updateStore);
 }
 
 export function logout(): Promise<void> {
-  return logoutAPI()
+  return API.logout()
     .then(() => manager.endSession());
 }
 
-export function changePassword(args: {password: string, token?: string}): Promise<void> {
-  return changePasswordAPI(args)
+export function changePassword(args: {password: string, currentPassword: string}): Promise<void> {
+  return API.changePassword(args)
+    .then(updateStore);
+}
+
+export function resetPassword(args: {password: string, token: string}): Promise<void> {
+  return API.resetPassword(args)
     .then(updateStore);
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -235,24 +235,14 @@ QUnit.test("success or failure", function(assert) {
 });
 
 QUnit.module("changePassword", startServer);
-QUnit.test("success with token", function(assert) {
+QUnit.test("success", function(assert) {
   this.server.respondWith('POST', 'https://authn.example.com/password',
     jsonResult({id_token: idToken({age: 1})})
   );
 
   return KeratinAuthN.changePassword({
       password: 'new',
-      token: jwt({foo: 'bar'})
-    })
-    .then(assertInstalledToken(assert));
-});
-QUnit.test("success with session", function(assert) {
-  this.server.respondWith('POST', 'https://authn.example.com/password',
-    jsonResult({id_token: idToken({age: 1})})
-  );
-
-  return KeratinAuthN.changePassword({
-      password: 'new'
+      currentPassword: 'old'
     })
     .then(assertInstalledToken(assert));
 });
@@ -262,6 +252,33 @@ QUnit.test("failure", function(assert) {
   );
 
   return KeratinAuthN.changePassword({
+      password: 'new',
+      currentPassword: 'wrong'
+    })
+    .then(refuteSuccess(assert))
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{field: 'foo', message: 'bar'}]);
+    });
+});
+
+QUnit.module("resetPassword", startServer);
+QUnit.test("success", function(assert) {
+  this.server.respondWith('POST', 'https://authn.example.com/password',
+    jsonResult({id_token: idToken({age: 1})})
+  );
+
+  return KeratinAuthN.resetPassword({
+      password: 'new',
+      token: jwt({foo: 'bar'})
+    })
+    .then(assertInstalledToken(assert));
+});
+QUnit.test("failure", function(assert) {
+  this.server.respondWith('POST', 'https://authn.example.com/password',
+    jsonErrors({foo: 'bar'})
+  );
+
+  return KeratinAuthN.resetPassword({
       password: 'new',
       token: jwt({foo: 'bar'})
     })


### PR DESCRIPTION
`changePassword` and `resetPassword` are now separate API methods with separate parameter requirements:

* `changePassword` requires `password`, `currentPassword`, and a current session
* `resetPassword` requires `pasword` and `token`

Note that `currentPassword` is slated for an [upcoming authn-server release](https://github.com/keratin/authn-server/pull/4). This change should be deployed first for seamless upgrades.