### PR TITLE
clear refresh timeout on logout

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -48,6 +48,7 @@ export default class SessionManager {
 
   endSession(): void {
     this.session = undefined;
+    clearTimeout(this.timeoutID);
     if (this.store) {
       this.store.delete();
     }

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -62,6 +62,10 @@ export default class SessionManager {
     const refreshAt = (this.session.iat() + this.session.halflife());
     const now = (new Date).getTime(); // in ms
 
+    if (isNaN(refreshAt)) {
+      throw new Error("Malformed JWT, can not calculate refreshAt");
+    }
+
     // NOTE: if the client's clock is quite wrong, we'll end up being pretty aggressive about
     // maintaining their session on pretty much every page load.
     if (now < this.session.iat() || now >= refreshAt) {


### PR DESCRIPTION
When logging out, clear any attempt at refreshing the token. This is good hygiene, and also provides a way for host applications to control dangling timeouts by invoking `logout`.