### PR TITLE
sync sessions across tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@ This library provides utilities to help integrate with AuthN from the browser. I
 
 ## Persistence Options
 
-KeratinAuthN offers three persistence modes, each useful to a different type of application:
+KeratinAuthN offers two persistence modes, each useful to a different type of application:
 
-1. **Memory:** By default, KeratinAuthN will only track a login in memory. This might be useful for single-page applications where the user can be logged out on each new page load.
+1. **LocalStorage:** Configuring `setLocalStorageStore(name: string)` adds localStorage-backed persistence. This is useful for client-side applications that do not rely on server-side rendering to generate a personalized page. The client is responsible for reading from `KeratinAuthN.session()` and adding the session token to any backend API requests, probably as a header.
 
-2. **LocalStorage:** Configuring `setLocalStorageStore(name: string)` adds localStorage-backed persistence. This is useful for client-side applications that do not rely on server-side rendering to generate a personalized page. The client is responsible for reading from `KeratinAuthN.session()` and adding the session token to any backend API requests, probably as a header.
-
-3. **Cookie:** Configuring `setCookieStore(name: string)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but requires the application to implement CSRF protection mechanisms.
+2. **Cookie:** Configuring `setCookieStore(name: string)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but also requires the application to implement CSRF protection mechanisms.
 
 ## Installation
 
@@ -53,7 +51,9 @@ KeratinAuthN.setCookieStore(name: string): void
 ```
 
 ```javascript
-// Configure AuthN to read and write from localStorage for session persistence.
+// Configure AuthN to read and write from localStorage for session persistence. In private browsing
+// mode with old versions of Safari and Android Browser (not Chrome), this will fall back to a
+// simple memory storage that is lost on page refresh.
 // Will not check for an existing cookie. See `restoreSession`.
 KeratinAuthN.setLocalStorageStore(name: string): void
 ```
@@ -69,7 +69,8 @@ KeratinAuthN.restoreSession(): Promise<void>
 ```
 
 ```javascript
-// Get the session (as a JWT) found in AuthN's current session store.
+// Get the session (as a JWT) found in AuthN's current session store. There is no guarantee this
+// session will be valid or fresh, especially on page load while restoreSession is working.
 KeratinAuthN.session(): string | undefined
 ```
 

--- a/src/LocalStorageSessionStore.ts
+++ b/src/LocalStorageSessionStore.ts
@@ -1,5 +1,15 @@
 import { SessionStore } from "./types";
-import JWTSession from "./JWTSession";
+
+export function localStorageSupported(): boolean {
+  const str = 'keratin-authn-test';
+  try {
+    window.localStorage.setItem(str, str);
+    window.localStorage.removeItem(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 export default class LocalStorageSessionStore implements SessionStore {
   private readonly sessionName: string;

--- a/src/MemorySessionStore.ts
+++ b/src/MemorySessionStore.ts
@@ -1,0 +1,17 @@
+import { SessionStore } from "./types";
+
+export default class MemorySessionStore implements SessionStore {
+  private session: string | undefined;
+
+  read() {
+    return this.session;
+  }
+
+  update(val: string) {
+    this.session = val;
+  }
+
+  delete() {
+    this.session = undefined;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export function setLocalStorageStore(sessionName: string): void {
 }
 
 export function session(): string | undefined {
-  return manager.session ? manager.session.token : undefined;
+  return manager.sessionToken();
 }
 
 export function signup(credentials: Credentials): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Credentials, SessionStore } from './types';
 import SessionManager from './SessionManager';
 import CookieSessionStore from "./CookieSessionStore";
-import LocalStorageSessionStore from "./LocalStorageSessionStore";
+import MemorySessionStore from './MemorySessionStore';
+import LocalStorageSessionStore, {localStorageSupported} from "./LocalStorageSessionStore";
 import * as API from './api';
 
 let manager = new SessionManager();
@@ -18,7 +19,9 @@ export function setCookieStore(sessionName: string): void {
 }
 
 export function setLocalStorageStore(sessionName: string): void {
-  setStore(new LocalStorageSessionStore(sessionName));
+  localStorageSupported() ?
+    setStore(new LocalStorageSessionStore(sessionName)) :
+    setStore(new MemorySessionStore);
 }
 
 export function session(): string | undefined {


### PR DESCRIPTION
Previously, tabs would not pick up session changes that happened in other tabs. This was caused by the memory caching in SessionManager, and primarily showed up in single-page apps using localStorage where the memory caching is more impactful.

Now, the SessionManager does not maintain that state but proxies tokens directly from the store as needed. This is not expected to have much performance impact, since reads are cheap and the public API only exposes the unprocessed, opaque token.

This does mean that `KeratinAuthN.session()` will more frequently return stale values, since it reads tokens directly from the store and does not checked for freshness. Single-page apps should rely on `restoreSession().then(...)` for sane page loads.

NOTE: `KeratinAuthN` does not notify if the session becomes revoked due to an out-of-band process like logging out in another tab. Single-page apps are advised to poll for changes in `Keratin.session()`.