### PR TITLE
importSession API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@ KeratinAuthN.setLocalStorageStore(name: string): void
 Use the following API methods to integrate your AuthN service:
 
 ```javascript
-// Check the configured storage for an existing session. Refresh it if necessary.
-// The promise is fulfilled if a session is restored.
+// Check the configured storage for an existing session. If a session is found but might be stale,
+// then refresh it. The promise is fulfilled if a session is restored.
 KeratinAuthN.restoreSession(): Promise<void>
+```
+
+```javascript
+// Attempt to import a session from AuthN. This is a more aggressive strategy than restoreSession,
+// because it does not check for an existing session before invoking the refresh API.
+KeratinAuthN.importSession(): Promise<void>
 ```
 
 ```javascript

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -93,6 +93,18 @@ export default class SessionManager {
     });
   }
 
+  refresh(): Promise<void> {
+    return refreshAPI().then(
+      (id_token) => this.update(id_token),
+      (errors) => {
+        if (errors[0] && errors[0].message === 'Unauthorized') {
+          this.endSession();
+        }
+        throw errors;
+      }
+    );
+  }
+
   private scheduleRefresh(): void {
     if (this.timeoutID) {
       clearTimeout(this.timeoutID);
@@ -103,17 +115,5 @@ export default class SessionManager {
         this.refreshAt - Date.now()
       );
     }
-  }
-
-  private refresh(): Promise<void> {
-    return refreshAPI().then(
-      (id_token) => this.update(id_token),
-      (errors) => {
-        if (errors[0] && errors[0].message === 'Unauthorized') {
-          this.endSession();
-        }
-        throw errors;
-      }
-    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ export function restoreSession(): Promise<void> {
   return manager.restoreSession();
 }
 
+export function importSession(): Promise<void> {
+  return manager.refresh();
+}
+
 export function setCookieStore(sessionName: string): void {
   setStore(new CookieSessionStore(sessionName));
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -225,6 +225,21 @@ QUnit.test("malformed JWT", function(assert) {
     });
 });
 
+QUnit.module("importSession", startServer);
+QUnit.test("no existing session", function(assert) {
+  deleteCookie('authn');
+  var newSession = idToken({age: 1});
+
+  this.server.respondWith('GET', 'https://authn.example.com/session/refresh',
+    jsonResult({id_token: newSession})
+  );
+
+  return KeratinAuthN.importSession()
+    .then(function () {
+      assert.equal(KeratinAuthN.session(), newSession, "session re-established");
+    });
+});
+
 QUnit.module("login", startServer);
 QUnit.test("success", function(assert) {
   this.server.respondWith('POST', 'https://authn.example.com/session',


### PR DESCRIPTION
`importSession` is a simpler version of `restoreSession` in that it does not check the status of the current session to efficiently resume on a page load. Instead, it immediately executes a `refresh` in case the user still has a valid refresh token.

This is useful for the final step of OAuth and for SSO.