### PR TITLE
Stop jhr XHR function from swallowing JSON.parse error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib/*
 dist
+.idea

--- a/src/verbs.ts
+++ b/src/verbs.ts
@@ -1,5 +1,5 @@
-import { StringMap } from "./types";
-import { KeratinError } from "./types";
+import {StringMap} from "./types";
+import {KeratinError} from "./types";
 import formData from "./formData";
 
 export function get<T>(url: string, data: StringMap): Promise<T> {
@@ -33,7 +33,7 @@ function jhr<T>(sender: (xhr: XMLHttpRequest) => void): Promise<T> {
     xhr.withCredentials = true; // enable authentication server cookies
     xhr.onreadystatechange = () => {
       if (xhr.readyState == XMLHttpRequest.DONE) {
-        const data: {result?: T, errors?: KeratinError[]} = (xhr.responseText.length > 1) ? JSON.parse(xhr.responseText) : {};
+        const data = maybeParseJSON<T>(xhr.responseText);
 
         if (data.result) {
           fulfill(data.result);
@@ -51,4 +51,15 @@ function jhr<T>(sender: (xhr: XMLHttpRequest) => void): Promise<T> {
     };
     sender(xhr);
   });
+}
+
+function maybeParseJSON<T>(response: string): { result?: T, errors?: KeratinError[] } {
+  if (response === '') {
+    return {}
+  }
+  try {
+    return JSON.parse(response)
+  } catch (err) {
+    return {errors: [{message: `HTTP response '${response}' is not JSON as expected: ${err}`}]}
+  }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -261,6 +261,21 @@ QUnit.test("failure", function(assert) {
     });
 });
 
+QUnit.test("Non JSON XHR response", function(assert) {
+  this.server.respondWith('POST', 'https://authn.example.com/session',
+    'Origin is not a trusted host.'
+  );
+
+  const expectedError = "HTTP response 'Origin is not a trusted host.' is not JSON as expected: SyntaxError: " +
+    "JSON.parse: unexpected character at line 1 column 1 of the JSON data"
+
+  return KeratinAuthN.login({username: 'test', password: 'test'})
+    .then(refuteSuccess(assert))
+    .catch(function(errors) {
+      assert.deepEqual(errors, [{message: expectedError}]);
+    });
+});
+
 QUnit.module("requestPasswordReset", startServer);
 QUnit.test("success or failure", function(assert) {
   this.server.respondWith('GET', 'https://authn.example.com/password/reset?username=test', '');


### PR DESCRIPTION
There are a number of circumstances where the server may return a non-empty non-JSON response:

- Connection refused
- Bad origin
- Failure to reverse proxy
- Other middleware

In these cases `jhr` dies silently and so the front end cannot easily display an error message. This change wraps the JSON parsing in a function with a try catch and returns an appropriate error.

I have an issue with the tests - the pass successfully in the browser (by loading runner.html) but they fail with `yarn test` which complains with `Failed assertion: expected: [object Object], but was: [object Object]`. This is different to failure in the browser UI that gives you a nice string diff between the objects. it seems like gulp-qunit is ending up with a different broken implementation of `deepEqual`. I tried upgrading `gulp-qunit` and `qunit` but it didn't help. Perhaps you have an idea how to fix, otherwise we can work around it some other way. It's odd because I don't see the difference between the other usages that work fine.