### PR TITLE
Allow to set Path and SameSite options for CookieSessionStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KeratinAuthN offers two persistence modes, each useful to a different type of ap
 
 1. **LocalStorage:** Configuring `setLocalStorageStore(name: string)` adds localStorage-backed persistence. This is useful for client-side applications that do not rely on server-side rendering to generate a personalized page. The client is responsible for reading from `KeratinAuthN.session()` and adding the session token to any backend API requests, probably as a header.
 
-2. **Cookie:** Configuring `setCookieStore(name: string, opts?: object)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but also requires the application to implement CSRF protection mechanisms. By passing an additional object to `setCookieStore(...)` it is also possible to configure the cookies path and SameSite attributes. For example, `setCookieStore("authn-token", {path: "/admin", sameSite: "Strict"})` will restrict the cookie to `/admin` and will exclude it from third-party top-level navigations.
+2. **Cookie:** Configuring `setCookieStore(name: string, opts?: object)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but also requires the application to implement CSRF protection mechanisms. By passing an additional object to `setCookieStore(...)` it is also possible to configure the cookies path and SameSite attributes. For example, `setCookieStore("authn-token", {path: "/admin", sameSite: "Strict"})` will restrict the cookie to `/admin` and will exclude it from third-party top-level navigations. If `sameSite` is not provided the browser will choose it's default value.
 
 ## Installation
 
@@ -47,7 +47,7 @@ KeratinAuthN.setHost(url: string): void
 ```javascript
 // Configure AuthN to read and write from a named cookie for session persistence.
 // Will not check for an existing cookie. See `restoreSession`.
-KeratinAuthN.setCookieStore(name: string, opts?: {path?: string, sameSite?: string}): void
+KeratinAuthN.setCookieStore(name: string, opts?: {path?: string, sameSite?: 'Lax' | 'Strict' | 'None'}): void
 ```
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KeratinAuthN offers two persistence modes, each useful to a different type of ap
 
 1. **LocalStorage:** Configuring `setLocalStorageStore(name: string)` adds localStorage-backed persistence. This is useful for client-side applications that do not rely on server-side rendering to generate a personalized page. The client is responsible for reading from `KeratinAuthN.session()` and adding the session token to any backend API requests, probably as a header.
 
-2. **Cookie:** Configuring `setCookieStore(name: string)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but also requires the application to implement CSRF protection mechanisms.
+2. **Cookie:** Configuring `setCookieStore(name: string, opts?: object)` adds support for cookie-backed persistence. This is useful for applications that rely on server-side rendering, but also requires the application to implement CSRF protection mechanisms. By passing an additional object to `setCookieStore(...)` it is also possible to configure the cookies path and SameSite attributes. For example, `setCookieStore("authn-token", {path: "/admin", sameSite: "Strict"})` will restrict the cookie to `/admin` and will exclude it from third-party top-level navigations.
 
 ## Installation
 
@@ -47,7 +47,7 @@ KeratinAuthN.setHost(url: string): void
 ```javascript
 // Configure AuthN to read and write from a named cookie for session persistence.
 // Will not check for an existing cookie. See `restoreSession`.
-KeratinAuthN.setCookieStore(name: string): void
+KeratinAuthN.setCookieStore(name: string, opts?: {path?: string, sameSite?: string}): void
 ```
 
 ```javascript

--- a/src/CookieSessionStore.ts
+++ b/src/CookieSessionStore.ts
@@ -2,7 +2,7 @@ import { SessionStore } from "./types";
 
 export interface CookieSessionStoreOptions {
     path?: string;
-    sameSite?: string;
+    sameSite?: 'Lax' | 'Strict' | 'None';
 }
 
 export default class CookieSessionStore implements SessionStore {

--- a/src/CookieSessionStore.ts
+++ b/src/CookieSessionStore.ts
@@ -1,13 +1,22 @@
 import { SessionStore } from "./types";
-import JWTSession from "./JWTSession";
+
+export interface CookieSessionStoreOptions {
+    path?: string;
+    sameSite?: string;
+}
 
 export default class CookieSessionStore implements SessionStore {
   private readonly sessionName: string;
   private readonly secureFlag: string;
+  private readonly path: string;
+  private readonly sameSite: string;
 
-  constructor(cookieName: string) {
+  constructor(cookieName: string, opts: CookieSessionStoreOptions = {}) {
     this.sessionName = cookieName;
     this.secureFlag = (window.location.protocol === 'https:') ? '; secure' : '';
+    this.path = !!opts.path ? `; path=${opts.path}` : '';
+    this.sameSite = !!opts.sameSite ? `; SameSite=${opts.sameSite}` : '';
+
   }
 
   read(): string | undefined {
@@ -15,7 +24,7 @@ export default class CookieSessionStore implements SessionStore {
   }
 
   update(val: string) {
-    document.cookie = `${this.sessionName}=${val}${this.secureFlag}`;
+    document.cookie = `${this.sessionName}=${val}${this.secureFlag}${this.path}${this.sameSite}`;
   }
 
   delete() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Credentials, SessionStore } from './types';
 import SessionManager from './SessionManager';
-import CookieSessionStore from "./CookieSessionStore";
+import CookieSessionStore, { CookieSessionStoreOptions } from "./CookieSessionStore";
 import MemorySessionStore from './MemorySessionStore';
 import LocalStorageSessionStore, {localStorageSupported} from "./LocalStorageSessionStore";
 import * as API from './api';
@@ -18,8 +18,8 @@ export function importSession(): Promise<void> {
   return manager.refresh();
 }
 
-export function setCookieStore(sessionName: string): void {
-  setStore(new CookieSessionStore(sessionName));
+export function setCookieStore(sessionName: string, opts?: CookieSessionStoreOptions): void {
+  setStore(new CookieSessionStore(sessionName, opts));
 }
 
 export function setLocalStorageStore(sessionName: string): void {


### PR DESCRIPTION
Hi,

this PR adds support to configure the `SameSite` and `path` cookie options when creating a new `CookieSessionStore` via `setCookieStore(...)`.

```javascript
AuthN.setCookieStore(`authn-token`, {
    path: '/',
    sameSite: 'Strict',
})
```

##  Problem

The problem this PR is trying to fix occurs when implementing SSO and using `AuthN.importSession()` to retrieve a new access token using an existing refresh token. Since `CookieSessionStore` does not specify the `path` option the browser uses the path currently entered in the URL bar.

That means that a different page (or a different component when using Angular/React) does not have access to that cookie:

1.) Open `http://app.example.com/` which calls `importSession` (assuming there's already one)
2.) The access token gets stored in the cookie with path `/`
3.) Browsing around the app works because every page has access to the cookie with the access token.
4.) Now, either the token expires and `refresh()` is called or a page reload occurs while on, for example, `http://app.example.com/profile`.
5.) A new access token is issued to the client which now stores it under path `/profile`.
6.) All of a sudden the application receives lots of 403 errors because only calls from the /profile page / component are correctly authenticated.

## Solution

It is easy to fix this by just settings the cookie path to "/" and allow every component/page of the application to access/use it. 

Since I was already adding support for the path option I also decided to add support for `SameSite` as it can help to better protect the user from CSRF attacks 
