### PR TITLE
Guard session store requests on the server

### DIFF
--- a/src/CookieSessionStore.ts
+++ b/src/CookieSessionStore.ts
@@ -13,26 +13,36 @@ export default class CookieSessionStore implements SessionStore {
 
   constructor(cookieName: string, opts: CookieSessionStoreOptions = {}) {
     this.sessionName = cookieName;
-    this.secureFlag = window.location.protocol === "https:" ? "; secure" : "";
+
     this.path = !!opts.path ? `; path=${opts.path}` : "";
     this.sameSite = !!opts.sameSite ? `; SameSite=${opts.sameSite}` : "";
+
+    if (typeof window !== "undefined") {
+      this.secureFlag = window.location.protocol === "https:" ? "; secure" : "";
+    }
   }
 
   read(): string | undefined {
-    return document.cookie.replace(
-      new RegExp(
-        `(?:(?:^|.*;\\\s*)${this.sessionName}\\\s*\\\=\\\s*([^;]*).*$)|^.*$`
-      ),
-      "$1"
-    );
+    if (typeof document !== "undefined") {
+      return document.cookie.replace(
+        new RegExp(
+          `(?:(?:^|.*;\\\s*)${this.sessionName}\\\s*\\\=\\\s*([^;]*).*$)|^.*$`
+        ),
+        "$1"
+      );
+    }
   }
 
   update(val: string) {
-    document.cookie = `${this.sessionName}=${val}${this.secureFlag}${this.path}${this.sameSite}`;
+    if (typeof document !== "undefined") {
+      document.cookie = `${this.sessionName}=${val}${this.secureFlag}${this.path}${this.sameSite}`;
+    }
   }
 
   delete() {
-    document.cookie =
-      this.sessionName + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+    if (typeof document !== "undefined") {
+      document.cookie =
+        this.sessionName + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+    }
   }
 }

--- a/src/LocalStorageSessionStore.ts
+++ b/src/LocalStorageSessionStore.ts
@@ -3,8 +3,10 @@ import { SessionStore } from "./types";
 export function localStorageSupported(): boolean {
   const str = "keratin-authn-test";
   try {
-    window.localStorage.setItem(str, str);
-    window.localStorage.removeItem(str);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(str, str);
+      window.localStorage.removeItem(str);
+    }
     return true;
   } catch (e) {
     return false;
@@ -19,14 +21,20 @@ export default class LocalStorageSessionStore implements SessionStore {
   }
 
   read(): string | undefined {
-    return window.localStorage.getItem(this.sessionName) || undefined;
+    if (typeof window !== "undefined") {
+      return window.localStorage.getItem(this.sessionName) || undefined;
+    }
   }
 
   update(val: string) {
-    window.localStorage.setItem(this.sessionName, val);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(this.sessionName, val);
+    }
   }
 
   delete() {
-    window.localStorage.removeItem(this.sessionName);
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(this.sessionName);
+    }
   }
 }


### PR DESCRIPTION
While the session refresh token and localstorage won't be useful on
the server, the AuthN package itself should ensure that it can be run
in server environments.

See https://github.com/keratin/authn-js/pull/34 for prior art.