### PR TITLE
cookies: add option for explicit TTL from session expiration

### DIFF
--- a/src/LocalStorageSessionStore.ts
+++ b/src/LocalStorageSessionStore.ts
@@ -26,7 +26,7 @@ export default class LocalStorageSessionStore implements SessionStore {
     }
   }
 
-  update(val: string) {
+  update(val: string, exp: number | undefined) {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(this.sessionName, val);
     }

--- a/src/MemorySessionStore.ts
+++ b/src/MemorySessionStore.ts
@@ -7,7 +7,7 @@ export default class MemorySessionStore implements SessionStore {
     return this.session;
   }
 
-  update(val: string) {
+  update(val: string, exp: number | undefined) {
     this.session = val;
   }
 

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -36,9 +36,8 @@ export default class SessionManager {
     if (!this.store) {
       return;
     }
-    this.store.update(id_token);
-
     const session = new JWTSession(id_token);
+    this.store.update(id_token, session.exp());
     this.refreshAt = Date.now() + session.halflife();
     this.scheduleRefresh();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export declare class Session {
 
 export interface SessionStore {
   read(): string | undefined;
-  update(val: string): void;
+  update(val: string, exp: number | undefined): void;
   delete(): void;
 }
 


### PR DESCRIPTION
We are seeing an issue on mobile safari where cookies with implied `expires= Session` don't survive with the tab and hoping setting an explicit TTL will help the browser hang onto them.